### PR TITLE
Allow for defined traps to have differing DeathNotes

### DIFF
--- a/DeathNotes.cs
+++ b/DeathNotes.cs
@@ -264,7 +264,10 @@ namespace Oxide.Plugins
                 }
                 else if (data.KillerEntityType == CombatEntityType.Turret
                     || data.KillerEntityType == CombatEntityType.Lock
-                    || data.KillerEntityType == CombatEntityType.Trap)
+                    || data.KillerEntityType == CombatEntityType.Trap
+                    || data.KillerEntityType == CombatEntityType.Landmine
+                    || data.KillerEntityType == CombatEntityType.BearTrap
+                    || data.KillerEntityType == CombatEntityType.ShotgunTrap)
                 {
                     replacements.Add("owner",
                         covalence.Players.FindPlayerById(data.KillerEntity.OwnerID.ToString())?.Name ?? "unknown owner"
@@ -309,8 +312,38 @@ namespace Oxide.Plugins
             if (entity == null)
                 return CombatEntityType.None;
 
+            // START AC - Check setting, allow filtering by Type
+
+            // First, lets check to see if this is a deployed guntrap
+            // This needs to go BEFORE the next default section to ensure that the 
+            // guntrap is not picked up as a standard trap!
+            if (entity.GetType().Name == "GunTrap")
+                return !_configuration.UseDefinedTraps
+                    ? CombatEntityType.Trap
+                    : CombatEntityType.ShotgunTrap;
+
             if (_combatEntityTypes.Contents != null && _combatEntityTypes.Contents.ContainsKey(entity.GetType().Name))
                 return _combatEntityTypes.Contents[entity.GetType().Name];
+
+            // Now deal with all other trap types
+            if (entity is BaseTrap)
+            {
+                if (!_configuration.UseDefinedTraps)
+                    return CombatEntityType.Trap;
+
+                switch (entity.GetType().Name)
+                {
+                    case "Landmine":
+                        return CombatEntityType.Landmine;
+                    case "GunTrap":
+                        return CombatEntityType.ShotgunTrap;
+                    case "BearTrap":
+                        return CombatEntityType.BearTrap;
+                    default:
+                        return CombatEntityType.Trap;
+                }
+            }
+            // END AC
 
             if (entity is BaseOven)
                 return CombatEntityType.HeatSource;
@@ -320,9 +353,6 @@ namespace Oxide.Plugins
 
             if (entity is BaseAnimalNPC)
                 return CombatEntityType.Animal;
-
-            if (entity is BaseTrap)
-                return CombatEntityType.Trap;
 
             if (entity is Barricade)
                 return CombatEntityType.Barricade;
@@ -408,7 +438,12 @@ namespace Oxide.Plugins
             Lock = 12,
             ScientistSentry = 13,
             Other = 14,
-            None = 15
+            None = 15,
+            // START AC - Possible Traps
+            BearTrap = 16,
+            Landmine = 17,
+            ShotgunTrap = 18
+            // END AC - Possible Traps
         }
 
         #endregion
@@ -753,6 +788,11 @@ namespace Oxide.Plugins
 
             [JsonProperty("Require Permission (deathnotes.cansee)")]
             public bool RequirePermission = false;
+
+            // START AC - Use Defined Traps
+            [JsonProperty("Use Defined Traps")]
+            public bool UseDefinedTraps = false;
+            // END AC - Use Defined Traps
 
             public void LoadDefaults()
             {

--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ You can use the default configuration as an example on what it looks like when h
 - ScientistSentry
 ```
 
+Enabling "Use Defined Traps" in the config seperates the "Trap" Killer Type to the following defined types, any that cannot be matched will list as the default of "Trap".  
+This allows you to have different DeathNote messages for differing traps (some which include the owner of the trap and some that do not).
+
+```yaml
+- Landmine
+- ShotgunTrap
+- BearTrap
+```
+
 
 ### Available Damage Types
 
@@ -168,7 +177,8 @@ Available for deaths involving a Player as the killer:
   "Show Kills in Console": true,
   "Show Kills in Chat": true,
   "MessageRadius": -1,
-  "Use Metric Distance": true
+  "Use Metric Distance": true,
+  "Use Defined Traps": false
 }
 ```
 


### PR DESCRIPTION
This update allows for server owners to chose if they wish to display differing DeathNotes for different types of traps.  This additional functionality is enabled by a Setting ("Use Defined Traps") and supports different messages for the Bear Trap, Landmine and Shotgun Trap.

This requirement was built for a PvP server that wished to display the owner for Landmines and Bear Traps but not Shotgun Traps.