### PR TITLE
Adds support for Tunnel Dweller, Vehicle Collisions and Heavy Scientist

### DIFF
--- a/DeathNotes.cs
+++ b/DeathNotes.cs
@@ -16,7 +16,7 @@ namespace Oxide.Plugins
     using WeaponPrefabs = DeathNotes.RemoteConfiguration<Dictionary<string, string>>;
     using CombatEntityTypes = DeathNotes.RemoteConfiguration<Dictionary<string, DeathNotes.CombatEntityType>>;
 
-    [Info("Death Notes", "LaserHydra", "6.3.6")]
+    [Info("Death Notes", "LaserHydra", "6.3.7")]
     class DeathNotes : RustPlugin
     {
         #region Fields
@@ -390,6 +390,10 @@ namespace Oxide.Plugins
                 case CombatEntityType.Scientist:
                 case CombatEntityType.Murderer:
                 case CombatEntityType.Scarecrow:
+
+                    if(entity.ShortPrefabName == "heavyscientist")
+                        return "Heavy Scientist";
+
                     var name = entity.ToPlayer()?.displayName;
 
                     return

--- a/DeathNotes.cs
+++ b/DeathNotes.cs
@@ -381,6 +381,12 @@ namespace Oxide.Plugins
                 case CombatEntityType.Helicopter:
                     return "Helicopter";
 
+                case CombatEntityType.Other:
+                    return "Other";
+
+                case CombatEntityType.None:
+                    return "None";
+
                 case CombatEntityType.Scientist:
                 case CombatEntityType.Murderer:
                 case CombatEntityType.Scarecrow:
@@ -425,7 +431,8 @@ namespace Oxide.Plugins
             Lock = 12,
             ScientistSentry = 13,
             Other = 14,
-            None = 15
+            None = 15,
+            TunnelDweller = 17
         }
 
         #endregion
@@ -504,6 +511,16 @@ namespace Oxide.Plugins
                 data.KillerEntityType = CombatEntityType.Helicopter;
                 return;
             }
+
+            // Vehicle Kills
+            if (data.KillerEntityType == CombatEntityType.Player && data.DamageType == DamageType.Generic) {
+                if (data.KillerEntity.ToPlayer().isMounted)
+                {
+                    data.DamageType = DamageType.Collision;
+                    return;
+                }
+            }
+
         }
 
         private struct AttackInfo

--- a/DeathNotes.cs
+++ b/DeathNotes.cs
@@ -16,7 +16,7 @@ namespace Oxide.Plugins
     using WeaponPrefabs = DeathNotes.RemoteConfiguration<Dictionary<string, string>>;
     using CombatEntityTypes = DeathNotes.RemoteConfiguration<Dictionary<string, DeathNotes.CombatEntityType>>;
 
-    [Info("Death Notes", "LaserHydra", "6.3.5")]
+    [Info("Death Notes", "LaserHydra", "6.3.6")]
     class DeathNotes : RustPlugin
     {
         #region Fields


### PR DESCRIPTION
Adds support for Tunnel Dwellers and vehicle collisions.

Requires `CombatEntityTypes.json` to have tunnel dwellers added as:
```  "tunneldweller": 17```
(Note: I wasn't sure of the conventions being used for the values here, so 17 may or may not be "correct")

Facilitates the messaging as per examples below in `config/DeathNotes.json`:

```
      {
        "KillerType": "TunnelDweller",
        "VictimType": "Player",
        "DamageType": "*",
        "Messages": [
          "{victim} was taken out by a {killer}."
        ]
      },
      {
        "KillerType": "Player",
        "VictimType": "TunnelDweller",
        "DamageType": "*",
        "Messages": [
          "{killer} took out a {victim} with their {weapon}."
        ]
      },
      {
        "KillerType": "Player",
        "VictimType": "Animal",
        "DamageType": "Collision",
        "Messages": [
          "{killer} ran over a {victim}."
        ]
      },
      {
        "KillerType": "Player",
        "VictimType": "Player",
        "DamageType": "Collision",
        "Messages": [
          "{killer} ran over {victim}."
        ]
      },
```